### PR TITLE
Refactor `import_connection_data()`

### DIFF
--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -41,7 +41,7 @@ class ConnectionHandler:
             print(e.args)
             raise MissingAttributeException(e.args[0], e.args[0])
 
-        connection = Connection(
+        return Connection(
             id=id,
             name=name,
             start_time=start_time,
@@ -51,8 +51,6 @@ class ConnectionHandler:
             ingress_port=ingress_port,
             egress_port=egress_port,
         )
-
-        return connection
 
     def import_connection(self, file):
         """

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -1,5 +1,7 @@
 import json
+
 from sdxdatamodel.models.connection import Connection
+
 from .exceptions import MissingAttributeException
 
 

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -28,15 +28,24 @@ class ConnectionHandler:
             name = data["name"]
             if "bandwidth_required" in data.keys():
                 bw = data["bandwidth_required"]
+            else:
+                bw = None
             if "latency_required" in data.keys():
                 la = data["latency_required"]
+            else:
+                la = None
             if "start_time" in data.keys():
                 start = data["start_time"]
+            else:
+                start = None
             if "end_time" in data.keys():
                 end = data["end_time"]
+            else:
+                end = None
             ingress = data["ingress_port"]
             egress = data["egress_port"]
         except KeyError as e:
+            print(e.args)
             raise MissingAttributeException(e.args[0], e.args[0])
 
         connection = Connection(

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -24,26 +24,19 @@ class ConnectionHandler:
             `name`id(), `ingress_port`, `egress_port` keys.
         """
         try:
+            # The fields id, name, ingress_port, and egress_port are
+            # required, and failure to find them in the dict must throw
+            # a KeyError.
             id = data["id"]
             name = data["name"]
-            if "bandwidth_required" in data.keys():
-                bandwidth_required = data["bandwidth_required"]
-            else:
-                bandwidth_required = None
-            if "latency_required" in data.keys():
-                latency_required = data["latency_required"]
-            else:
-                latency_required = None
-            if "start_time" in data.keys():
-                start_time = data["start_time"]
-            else:
-                start_time = None
-            if "end_time" in data.keys():
-                end_time = data["end_time"]
-            else:
-                end_time = None
             ingress_port = data["ingress_port"]
             egress_port = data["egress_port"]
+
+            # Other fields are optional, and can be None.
+            bandwidth_required = data.get("bandwidth_required", None)
+            latency_required = data.get("latency_required", None)
+            start_time = data.get("start_time", None)
+            end_time = data.get("end_time", None)
         except KeyError as e:
             print(e.args)
             raise MissingAttributeException(e.args[0], e.args[0])

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -27,23 +27,23 @@ class ConnectionHandler:
             id = data["id"]
             name = data["name"]
             if "bandwidth_required" in data.keys():
-                bw = data["bandwidth_required"]
+                bandwidth_required = data["bandwidth_required"]
             else:
-                bw = None
+                bandwidth_required = None
             if "latency_required" in data.keys():
-                la = data["latency_required"]
+                latency_required = data["latency_required"]
             else:
-                la = None
+                latency_required = None
             if "start_time" in data.keys():
-                start = data["start_time"]
+                start_time = data["start_time"]
             else:
-                start = None
+                start_time = None
             if "end_time" in data.keys():
-                end = data["end_time"]
+                end_time = data["end_time"]
             else:
-                end = None
-            ingress = data["ingress_port"]
-            egress = data["egress_port"]
+                end_time = None
+            ingress_port = data["ingress_port"]
+            egress_port = data["egress_port"]
         except KeyError as e:
             print(e.args)
             raise MissingAttributeException(e.args[0], e.args[0])
@@ -51,12 +51,12 @@ class ConnectionHandler:
         connection = Connection(
             id=id,
             name=name,
-            start_time=start,
-            end_time=end,
-            bandwidth=bw,
-            latency=la,
-            ingress_port=ingress,
-            egress_port=egress,
+            start_time=start_time,
+            end_time=end_time,
+            bandwidth=bandwidth_required,
+            latency=latency_required,
+            ingress_port=ingress_port,
+            egress_port=egress_port,
         )
 
         return connection

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -40,7 +40,6 @@ class ConnectionHandler:
             start_time = data.get("start_time", None)
             end_time = data.get("end_time", None)
         except KeyError as e:
-            print(e.args)
             raise MissingAttributeException(e.args[0], e.args[0])
 
         return Connection(

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -4,16 +4,25 @@ from .exceptions import MissingAttributeException
 
 
 class ConnectionHandler:
+    """
+    Parse connection request descritpions.
 
-    """ "
-    Handler for parsing the connection request descritpion in json
+    Connection request descritpions may be either JSON documents or
+    Python dicts.
     """
 
     def __init__(self):
+        """Construct a ConnectionHandler."""
         super().__init__()
         self.connection = None
 
     def import_connection_data(self, data):
+        """
+        Create a Connection from connection data encoded in a dict.
+
+        :param data: a dict containing, at a minimum, `id`,
+            `name`id(), `ingress_port`, `egress_port` keys.
+        """
         try:
             id = data["id"]
             name = data["name"]
@@ -44,9 +53,15 @@ class ConnectionHandler:
         return connection
 
     def import_connection(self, file):
+        """
+        Import connection descritpion from a file.
+
+        :param file: a JSON document.
+        """
         with open(file, "r", encoding="utf-8") as data_file:
             data = json.load(data_file)
             self.connection = self.import_connection_data(data)
 
     def get_connection(self):
+        """Return connection state."""
         return self.connection

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -61,6 +61,7 @@ class ConnectionHandler:
         with open(file, "r", encoding="utf-8") as data_file:
             data = json.load(data_file)
             self.connection = self.import_connection_data(data)
+        return self.connection
 
     def get_connection(self):
         """Return connection state."""

--- a/sdxdatamodel/parsing/connectionhandler.py
+++ b/sdxdatamodel/parsing/connectionhandler.py
@@ -2,10 +2,11 @@ import json
 from sdxdatamodel.models.connection import Connection
 from .exceptions import MissingAttributeException
 
-class ConnectionHandler():
 
-    """"
-    Handler for parsing the connection request descritpion in json 
+class ConnectionHandler:
+
+    """ "
+    Handler for parsing the connection request descritpion in json
     """
 
     def __init__(self):
@@ -14,27 +15,36 @@ class ConnectionHandler():
 
     def import_connection_data(self, data):
         try:
-            id = data['id']
-            name=data['name']
-            if 'bandwidth_required' in data.keys():
-                bw=data['bandwidth_required']
-            if 'latency_required' in data.keys():
-                la=data['latency_required']
-            if 'start_time' in data.keys():
-                start=data['start_time']
-            if 'end_time' in data.keys():    
-                end=data['end_time']
-            ingress=data['ingress_port']
-            egress=data['egress_port']
+            id = data["id"]
+            name = data["name"]
+            if "bandwidth_required" in data.keys():
+                bw = data["bandwidth_required"]
+            if "latency_required" in data.keys():
+                la = data["latency_required"]
+            if "start_time" in data.keys():
+                start = data["start_time"]
+            if "end_time" in data.keys():
+                end = data["end_time"]
+            ingress = data["ingress_port"]
+            egress = data["egress_port"]
         except KeyError as e:
-            raise MissingAttributeException(e.args[0],e.args[0])
+            raise MissingAttributeException(e.args[0], e.args[0])
 
-        connection=Connection(id=id, name=name, start_time = start, end_time = end, bandwidth=bw, latency=la, ingress_port = ingress, egress_port = egress)
+        connection = Connection(
+            id=id,
+            name=name,
+            start_time=start,
+            end_time=end,
+            bandwidth=bw,
+            latency=la,
+            ingress_port=ingress,
+            egress_port=egress,
+        )
 
         return connection
-    
-    def import_connection(self,file):
-        with open(file, 'r', encoding='utf-8') as data_file:
+
+    def import_connection(self, file):
+        with open(file, "r", encoding="utf-8") as data_file:
             data = json.load(data_file)
             self.connection = self.import_connection_data(data)
 

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -1,13 +1,15 @@
 import unittest
 
 # import parsing
+import os
 
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
 from sdxdatamodel.parsing.exceptions import DataModelException
 
-CONNECTION_P2P = "./tests/data/p2p.json"
-# CONNECTION_P2P = './tests/data/test_connection.json'
-
+# Test data is present inside current module's directory.
+TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+CONNECTION_FILE_P2P = os.path.join(TEST_DATA_DIR, "p2p.json")
+CONNECTION_FILE_REQ = os.path.join(TEST_DATA_DIR, "test_request.json")
 
 class TestConnectionHandler(unittest.TestCase):
     def setUp(self):
@@ -19,7 +21,7 @@ class TestConnectionHandler(unittest.TestCase):
     def testImportConnection_p2p(self):
         try:
             print("Test Connection")
-            self.handler.import_connection(CONNECTION_P2P)
+            self.handler.import_connection(CONNECTION_FILE_P2P)
             print(self.handler.connection)
         except DataModelException as e:
             print(e)

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -48,6 +48,14 @@ class TestConnectionHandler(unittest.TestCase):
             {"id": "id", "name": "name", "ingress_port": []},
         )
 
+    def testImportConnection_MissingOptionalAttributes(self):
+        """No error expected when optional attributes are missing."""
+        # All required attributes are set.
+        connection = self.handler.import_connection_data(
+            {"id": "id", "name": "name", "ingress_port": [], "egress_port": []}
+        )
+        self.assertIsInstance(connection, Connection)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -27,15 +27,9 @@ class TestConnectionHandler(unittest.TestCase):
         connection = self.handler.import_connection(CONNECTION_FILE_P2P)
         self.assertIsInstance(connection, Connection)
 
-    def testImportConnection_regular(self):
-        try:
-            print("Test Connection")
-            self.handler.import_connection(CONNECTION_FILE_REQ)
-            print(self.handler.connection)
-        except DataModelException as e:
-            print(e)
-            return False
-        return True
+    def testImportConnection_req(self):
+        connection = self.handler.import_connection(CONNECTION_FILE_REQ)
+        self.assertIsInstance(connection, Connection)
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -4,7 +4,7 @@ import unittest
 import os
 
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
-from sdxdatamodel.parsing.exceptions import DataModelException
+from sdxdatamodel.parsing.exceptions import DataModelException, MissingAttributeException
 
 from sdxdatamodel.models.connection import Connection
 
@@ -30,6 +30,15 @@ class TestConnectionHandler(unittest.TestCase):
     def testImportConnection_req(self):
         connection = self.handler.import_connection(CONNECTION_FILE_REQ)
         self.assertIsInstance(connection, Connection)
+
+    def testImportConnection_MissingRequiredAttributes(self):
+        """Exception expected when required attributes are missing."""
+        try:
+            # No attributes set in input data.
+            self.handler.import_connection_data({})
+        except MissingAttributeException:
+            return True
+        return False
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -1,12 +1,9 @@
+import os
 import unittest
 
-# import parsing
-import os
-
+from sdxdatamodel.models.connection import Connection
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
 from sdxdatamodel.parsing.exceptions import MissingAttributeException
-
-from sdxdatamodel.models.connection import Connection
 
 # Test data is present inside current module's directory.
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -28,6 +28,16 @@ class TestConnectionHandler(unittest.TestCase):
             return False
         return True
 
+    def testImportConnection_regular(self):
+        try:
+            print("Test Connection")
+            self.handler.import_connection(CONNECTION_FILE_REQ)
+            print(self.handler.connection)
+        except DataModelException as e:
+            print(e)
+            return False
+        return True
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -4,7 +4,10 @@ import unittest
 import os
 
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
-from sdxdatamodel.parsing.exceptions import DataModelException, MissingAttributeException
+from sdxdatamodel.parsing.exceptions import (
+    DataModelException,
+    MissingAttributeException,
+)
 
 from sdxdatamodel.models.connection import Connection
 
@@ -33,7 +36,9 @@ class TestConnectionHandler(unittest.TestCase):
 
     def testImportConnection_MissingRequiredAttributes(self):
         """Exception expected when required attributes are missing."""
-        self.assertRaises(MissingAttributeException, self.handler.import_connection_data, {})
+        self.assertRaises(
+            MissingAttributeException, self.handler.import_connection_data, {}
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -4,9 +4,7 @@ import unittest
 import os
 
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
-from sdxdatamodel.parsing.exceptions import (
-    MissingAttributeException,
-)
+from sdxdatamodel.parsing.exceptions import MissingAttributeException
 
 from sdxdatamodel.models.connection import Connection
 

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -11,7 +11,10 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 CONNECTION_FILE_P2P = os.path.join(TEST_DATA_DIR, "p2p.json")
 CONNECTION_FILE_REQ = os.path.join(TEST_DATA_DIR, "test_request.json")
 
+
 class TestConnectionHandler(unittest.TestCase):
+    """Test ConnectionHandler class."""
+
     def setUp(self):
         self.handler = ConnectionHandler()  # noqa: E501
 

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -1,17 +1,18 @@
 import unittest
 
-#import parsing
+# import parsing
 
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
 from sdxdatamodel.parsing.exceptions import DataModelException
 
-CONNECTION_P2P = './tests/data/p2p.json'
-#CONNECTION_P2P = './tests/data/test_connection.json'
+CONNECTION_P2P = "./tests/data/p2p.json"
+# CONNECTION_P2P = './tests/data/test_connection.json'
+
 
 class TestConnectionHandler(unittest.TestCase):
-
     def setUp(self):
         self.handler = ConnectionHandler()  # noqa: E501
+
     def tearDown(self):
         pass
 
@@ -22,8 +23,9 @@ class TestConnectionHandler(unittest.TestCase):
             print(self.handler.connection)
         except DataModelException as e:
             print(e)
-            return False      
+            return False
         return True
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -33,12 +33,7 @@ class TestConnectionHandler(unittest.TestCase):
 
     def testImportConnection_MissingRequiredAttributes(self):
         """Exception expected when required attributes are missing."""
-        try:
-            # No attributes set in input data.
-            self.handler.import_connection_data({})
-        except MissingAttributeException:
-            return True
-        return False
+        self.assertRaises(MissingAttributeException, self.handler.import_connection_data, {})
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -33,6 +33,20 @@ class TestConnectionHandler(unittest.TestCase):
         self.assertRaises(
             MissingAttributeException, self.handler.import_connection_data, {}
         )
+        self.assertRaises(
+            MissingAttributeException, self.handler.import_connection_data,
+            {"id": "id"}
+        )
+        self.assertRaises(
+            MissingAttributeException,
+            self.handler.import_connection_data,
+            {"id": "id", "name": "name"},
+        )
+        self.assertRaises(
+            MissingAttributeException,
+            self.handler.import_connection_data,
+            {"id": "id", "name": "name", "ingress_port": []},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -45,7 +45,17 @@ class TestConnectionHandler(unittest.TestCase):
         self.assertRaises(
             MissingAttributeException,
             self.handler.import_connection_data,
-            {"id": "id", "name": "name", "ingress_port": []},
+            {"id": "id", "name": "name", "ingress_port": None},
+        )
+        self.assertRaises(
+            MissingAttributeException,
+            self.handler.import_connection_data,
+            {"id": "id", "name": "name", "egress_port": None},
+        )
+        self.assertRaises(
+            MissingAttributeException,
+            self.handler.import_connection_data,
+            {"id": "id", "egress_port": None, "ingress_port": None},
         )
 
     def testImportConnection_MissingOptionalAttributes(self):

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -24,8 +24,7 @@ class TestConnectionHandler(unittest.TestCase):
         pass
 
     def testImportConnection_p2p(self):
-        self.handler.import_connection(CONNECTION_FILE_P2P)
-        connection = self.handler.get_connection()
+        connection = self.handler.import_connection(CONNECTION_FILE_P2P)
         self.assertIsInstance(connection, Connection)
 
     def testImportConnection_regular(self):

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -51,8 +51,15 @@ class TestConnectionHandler(unittest.TestCase):
     def testImportConnection_MissingOptionalAttributes(self):
         """No error expected when optional attributes are missing."""
         # All required attributes are set.
+        ingress_port = {"id": "ingress_port_id", "name": "ingress_port_name"}
+        egress_port = {"id": "egress_port_id", "name": "egress_port_name"}
         connection = self.handler.import_connection_data(
-            {"id": "id", "name": "name", "ingress_port": [], "egress_port": []}
+            {
+                "id": "id",
+                "name": "name",
+                "ingress_port": ingress_port,
+                "egress_port": egress_port,
+            }
         )
         self.assertIsInstance(connection, Connection)
 

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -5,7 +5,6 @@ import os
 
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
 from sdxdatamodel.parsing.exceptions import (
-    DataModelException,
     MissingAttributeException,
 )
 

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -6,6 +6,8 @@ import os
 from sdxdatamodel.parsing.connectionhandler import ConnectionHandler
 from sdxdatamodel.parsing.exceptions import DataModelException
 
+from sdxdatamodel.models.connection import Connection
+
 # Test data is present inside current module's directory.
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 CONNECTION_FILE_P2P = os.path.join(TEST_DATA_DIR, "p2p.json")
@@ -22,14 +24,9 @@ class TestConnectionHandler(unittest.TestCase):
         pass
 
     def testImportConnection_p2p(self):
-        try:
-            print("Test Connection")
-            self.handler.import_connection(CONNECTION_FILE_P2P)
-            print(self.handler.connection)
-        except DataModelException as e:
-            print(e)
-            return False
-        return True
+        self.handler.import_connection(CONNECTION_FILE_P2P)
+        connection = self.handler.get_connection()
+        self.assertIsInstance(connection, Connection)
 
     def testImportConnection_regular(self):
         try:

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -16,7 +16,7 @@ class TestConnectionHandler(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def testImportConnection(self):
+    def testImportConnection_p2p(self):
         try:
             print("Test Connection")
             self.handler.import_connection(CONNECTION_P2P)


### PR DESCRIPTION
Addresses #46.  The diff looks big, but the changes are pretty simple:

- When optional arguments necessary to form a `Connection` are not passed to `import_connection_data()`, set them to `None`.  They are start time, end time, latency, and bandwidth.
- Expand tests to prove that `import_connection_data()` behaves as expected.
- When checking properties of `import_connection_data()`, use assertions provided by `unitest.TestCase`.
- Run black over the affected files for consistent formatting.
- Add some docstrings.