### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov wheel build
+          pip install flake8 pytest pytest-cov wheel build coverage
 
       - name: Lint with flake8
         run: |
@@ -57,6 +57,7 @@ jobs:
         run: |
           pip install .[test]
           pytest
+          coverage lcov
 
       - name: Build packages
         run: |
@@ -66,6 +67,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           flag-name: run-${{ join(matrix.*, '-') }}
+          file: coverage.lcov
           parallel: true
 
   finalize:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           pip install .[test]
           pytest
-          coverage lcov
+          coverage lcov -o coverage.lcov
 
       - name: Build packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,22 +63,18 @@ jobs:
           python -m build
 
       - name: Send coverage data to coveralls.io
-        run: |
-          python -m coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-          COVERALLS_PARALLEL: true
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: run-${{ join(matrix.*, '-') }}
+          parallel: true
 
   finalize:
     name: finalize
     needs: test
+    if: ${{ always() }}
     runs-on: ubuntu-latest
-    container: python:3-slim
     steps:
       - name: Indicate completion to coveralls.io
-        run: |
-          pip --no-cache-dir install --upgrade coveralls
-          python -m coveralls --service=github --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov wheel coveralls build
+          pip install flake8 pytest pytest-cov wheel build
 
       - name: Lint with flake8
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist/
 /.coverage.*
 /.coverage.el
 /coverage.xml
+/coverage.lcov


### PR DESCRIPTION
Issue is #98.  

Instead of using [coveralls-python](https://github.com/TheKevJames/coveralls-python), which occasionally fails with an opaque error mesage (as described in the linked issue), use [Coveralls GitHub Action](https://github.com/marketplace/actions/coveralls-github-action).