### PR TITLE
add the status/state back to port object

### DIFF
--- a/src/sdx_datamodel/models/port.py
+++ b/src/sdx_datamodel/models/port.py
@@ -59,6 +59,7 @@ class Port(object):
         node=None,
         label_range=None,
         status=None,
+        state=None,
         private_attributes=None,
     ):
         """Port - a model defined in Swagger"""
@@ -67,7 +68,6 @@ class Port(object):
         self._short_name = None
         self._node = None
         self._label_range = None
-        self._status = None
         self._private_attributes = None
         self._id = id
         self._name = name
@@ -77,6 +77,7 @@ class Port(object):
         if label_range is not None:
             self._label_range = label_range
         self._status = status
+        self._state = None
         if private_attributes is not None:
             self._private_attributes = private_attributes
 

--- a/src/sdx_datamodel/parsing/porthandler.py
+++ b/src/sdx_datamodel/parsing/porthandler.py
@@ -29,6 +29,8 @@ class PortHandler:
             node = data.get("node")
             short_name = data.get("short_name")
             label_range = data.get("label_range")
+            status = data.get("status")
+            state = data.get("state")
             private_attributes = data.get("private_attributes")
 
             # L2VPN services are optional.
@@ -51,7 +53,8 @@ class PortHandler:
             short_name=short_name,
             node=node,
             label_range=label_range,
-            status=None,
+            status=status,
+            state=state,
             private_attributes=private_attributes,
         )
 


### PR DESCRIPTION
1. added the status and state fields back to port object init. The getter/setter are still there. 
(At one time last year, we thought these two should be filtered out in LC/OXP because they are for network management, not control purpose)

Note: @sajith It appeared the latest setup tools_scm requires the 'dev' tag has to be '.dev0'. See:

https://github.com/pypa/setuptools_scm/blob/main/src/setuptools_scm/_modify_version.py
L21.

I had to do 'git tag -d 2.0.6.dev1' to remove the current tag in order to install. 
  