### PR TITLE
remove the legacy ogf:network in urns in the last a few test jsons

### DIFF
--- a/src/sdx_datamodel/data/requests/test_request.json
+++ b/src/sdx_datamodel/data/requests/test_request.json
@@ -12,7 +12,7 @@
         "status": "up"
     },
     "ingress_port": {
-        "id": "urn:ogf:network:sdx:port:zaoxi:A1:2",
+        "id": "urn:sdx:port:zaoxi:A1:2",
         "name": "Novi100:2",
         "node": "urn:ogf:network:sdx:node:zaoxi:A1",
         "status": "up"

--- a/src/sdx_datamodel/data/requests/test_request_no_node.json
+++ b/src/sdx_datamodel/data/requests/test_request_no_node.json
@@ -10,7 +10,7 @@
         "name": "Novi100:1"
     },
     "ingress_port": {
-        "id": "urn:ogf:network:sdx:port:zaoxi:A1:2",
+        "id": "urn:sdx:port:zaoxi:A1:2",
         "name": "Novi100:2"
     }
 }

--- a/src/sdx_datamodel/data/topologies/amlight_link_failure.json
+++ b/src/sdx_datamodel/data/topologies/amlight_link_failure.json
@@ -1,5 +1,5 @@
 {
-    "id": "urn:ogf:network:sdx:topology:amlight.net",
+    "id": "urn:sdx:topology:amlight.net",
     "name": "AmLight-OXP",
     "model_version": "1.0.0",
     "timestamp": "2000-01-23T04:56:07+00:00",
@@ -7,13 +7,13 @@
     "link_failure": [{
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:amlight:B1-B2",
+            "id": "urn:sdx:link:amlight:B1-B2",
             "latency": 5,
             "name": "amlight:B1-B2",
             "packet_loss": 59.621339166831824,
             "ports": [
                 {
-                    "id": "urn:ogf:network:sdx:port:zaoxi:A1:2",
+                    "id": "urn:sdx:port:zaoxi:A1:2",
                     "name": "Novi01:2",
                     "node": "urn:sdx:node:amlight.net:B1",
                     "short_name": "B1:2",
@@ -24,7 +24,7 @@
                     "status": "up"
                 },
                 {
-                    "id": "urn:ogf:network:sdx:port:zaoxi:B1:1",
+                    "id": "urn:sdx:port:zaoxi:B1:1",
                     "label_range": [
                         "100-200",
                         "10001"
@@ -42,7 +42,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:amlight:B1-B2",
+            "id": "urn:sdx:link:amlight:B1-B2",
             "latency": 5,
             "name": "amlight:B1-B2",
             "packet_loss": 59.621339166831824,
@@ -76,7 +76,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:amlight:A1-B1",
+            "id": "urn:sdx:link:amlight:A1-B1",
             "latency": 5,
             "name": "amlight:A1-B1",
             "packet_loss": 59.621339166831824,
@@ -110,7 +110,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:amlight:A1-B2",
+            "id": "urn:sdx:link:amlight:A1-B2",
             "latency": 5,
             "name": "amlight:A1-B2",
             "packet_loss": 59.621339166831824,
@@ -144,7 +144,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:nni:Miami-Sanpaolo",
+            "id": "urn:sdx:link:nni:Miami-Sanpaolo",
             "latency": 10,
             "name": "nni:Miami-Sanpaolo",
             "packet_loss": 59.621339166831824,
@@ -162,9 +162,9 @@
                     "status": "up"
                 },
                 {
-                    "id": "urn:ogf:network:sdx:port:sax:B1:1",
+                    "id": "urn:sdx:port:sax:B1:1",
                     "name": "Novi01:1",
-                    "node": "urn:ogf:network:sdx:port:sax:B1",
+                    "node": "urn:sdx:port:sax:B1",
                     "short_name": "B1:1",
                     "label_range": [
                         "100-200",
@@ -179,7 +179,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:nni:BocaRaton-Fortaleza",
+            "id": "urn:sdx:link:nni:BocaRaton-Fortaleza",
             "latency": 10,
             "name": "nni:BocaRaton-Fortaleza",
             "packet_loss": 59.621339166831824,
@@ -197,13 +197,13 @@
                     "status": "up"
                 },
                 {
-                    "id": "urn:ogf:network:sdx:port:sax:B2:1",
+                    "id": "urn:sdx:port:sax:B2:1",
                     "label_range": [
                         "100-200",
                         "1000"
                     ],
                     "name": "Novi02:1",
-                    "node": "urn:ogf:network:sdx:node:sax:B2",
+                    "node": "urn:sdx:node:sax:B2",
                     "short_name": "B2:1",
                     "status": "up"
                 }

--- a/src/sdx_datamodel/data/topologies/amlight_user_port.json
+++ b/src/sdx_datamodel/data/topologies/amlight_user_port.json
@@ -1,5 +1,5 @@
 {
-    "id": "urn:ogf:network:sdx:topology:amlight.net",
+    "id": "urn:sdx:topology:amlight.net",
     "name": "AmLight-OXP",
     "model_version": "1.0.0",
     "timestamp": "2000-01-23T04:56:07+00:00",
@@ -8,7 +8,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:amlight:B1-B2",
+            "id": "urn:sdx:link:amlight:B1-B2",
             "latency": 5,
             "name": "amlight:B1-B2",
             "packet_loss": 59.621339166831824,
@@ -42,7 +42,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:amlight:A1-B1",
+            "id": "urn:sdx:link:amlight:A1-B1",
             "latency": 5,
             "name": "amlight:A1-B1",
             "packet_loss": 59.621339166831824,
@@ -76,7 +76,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:amlight:A1-B2",
+            "id": "urn:sdx:link:amlight:A1-B2",
             "latency": 5,
             "name": "amlight:A1-B2",
             "packet_loss": 59.621339166831824,
@@ -110,7 +110,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:nni:Miami-Sanpaolo",
+            "id": "urn:sdx:link:nni:Miami-Sanpaolo",
             "latency": 10,
             "name": "nni:Miami-Sanpaolo",
             "packet_loss": 59.621339166831824,
@@ -128,9 +128,9 @@
                     "status": "up"
                 },
                 {
-                    "id": "urn:ogf:network:sdx:port:sax:B1:1",
+                    "id": "urn:sdx:port:sax:B1:1",
                     "name": "Novi01:1",
-                    "node": "urn:ogf:network:sdx:port:sax:B1",
+                    "node": "urn:sdx:port:sax:B1",
                     "short_name": "B1:1",
                     "label_range": [
                         "100-200",
@@ -145,7 +145,7 @@
         {
             "availability": 56.37376656633328,
             "residual_bandwidth": 100000,
-            "id": "urn:ogf:network:sdx:link:nni:BocaRaton-Fortaleza",
+            "id": "urn:sdx:link:nni:BocaRaton-Fortaleza",
             "latency": 10,
             "name": "nni:BocaRaton-Fortaleza",
             "packet_loss": 59.621339166831824,
@@ -163,13 +163,13 @@
                     "status": "up"
                 },
                 {
-                    "id": "urn:ogf:network:sdx:port:sax:B2:1",
+                    "id": "urn:sdx:port:sax:B2:1",
                     "label_range": [
                         "100-200",
                         "1000"
                     ],
                     "name": "Novi02:1",
-                    "node": "urn:ogf:network:sdx:node:sax:B2",
+                    "node": "urn:sdx:node:sax:B2",
                     "short_name": "B2:1",
                     "status": "up"
                 }


### PR DESCRIPTION
This is to close this issue:

Note: Latest Spec 2.0 doc doesn't have the 'domain service' attribute for the OXP topology JSON. 
Thought the related fields are still kept in schema json.