### PR TITLE
Using port IDs map to get nodes of a link

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -30,6 +30,12 @@ class TopologyTests(unittest.TestCase):
         self.assertIsNotNone(port1)
         self.assertIsNotNone(port2)
 
+        n1, port1, n2, port2 = topology.get_port_by_link(
+            "urn:sdx:node:amlight.net:B2", "urn:sdx:node:amlight.net:B1"
+        )
+        self.assertIsNotNone(port1)
+        self.assertIsNotNone(port2)
+
     def test_has_node_by_id(self):
         topology = TopologyHandler().import_topology(
             TestData.TOPOLOGY_FILE_AMLIGHT

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,6 +1,5 @@
 import json
 import unittest
-
 from unittest.mock import MagicMock, patch
 
 from sdx_datamodel.models.link import Link

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,6 +1,8 @@
 import json
 import unittest
 
+from unittest.mock import MagicMock, patch
+
 from sdx_datamodel.models.link import Link
 from sdx_datamodel.models.service import Service
 from sdx_datamodel.models.topology import Topology
@@ -73,3 +75,15 @@ class TopologyTests(unittest.TestCase):
         link = Link()
         link.set_ports([port1, port2])
         self.assertEqual(link.ports, ports)
+
+    def test_setter_nodes(self):
+        """Test Topology.nodes setter."""
+        topo = Topology(nodes=[], links=[])
+        topo._update_port_by_id = MagicMock()
+        with self.assertRaises(ValueError):
+            topo.nodes = None
+        topo.nodes = []
+        topo._update_port_by_id.assert_called_with([])
+
+        topo.add_nodes([1])
+        topo._update_port_by_id.assert_called_with([1])


### PR DESCRIPTION
Fix #134 

## Description of the change

This change proposal adds a port IDs map into the topology datamodel to keep track of the port IDs and mapping them into the actual port. Thus, the function `get_port_by_link()` leverages that port map to find the nodes in a link, while keeping backwards compatibility.