### PR TITLE
Enhancements and fixes for L2VPN creation - Connection v2

### DIFF
--- a/src/sdx_datamodel/models/port.py
+++ b/src/sdx_datamodel/models/port.py
@@ -22,7 +22,7 @@ class Port(Model):
         name=None,
         short_name=None,
         node=None,
-        label_range=None,
+        vlan_range=None,
         status=None,
         state=None,
         nni=None,
@@ -39,8 +39,8 @@ class Port(Model):
         :type short_name: str
         :param node: The node of this Port.  # noqa: E501
         :type node: str
-        :param label_range: The label_range of this Port.  # noqa: E501
-        :type label_range: List[str]
+        :param vlan_range: The vlan range of this Port.  # noqa: E501
+        :type vlan_range: List[str]
         :param status: The status of this Port.  # noqa: E501
         :type status: str
         :param state: The state of this Port.  # noqa: E501
@@ -57,7 +57,7 @@ class Port(Model):
             "name": str,
             "short_name": str,
             "node": str,
-            "label_range": List[str],
+            "vlan_range": List[str],
             "status": str,
             "state": str,
             "nni": str,
@@ -70,7 +70,7 @@ class Port(Model):
             "name": "name",
             "short_name": "short_name",
             "node": "node",
-            "label_range": "label_range",
+            "vlan_range": "vlan_range",
             "status": "status",
             "state": "state",
             "nni": "nni",
@@ -81,7 +81,7 @@ class Port(Model):
         self._name = name
         self._short_name = short_name
         self._node = node
-        self._label_range = label_range
+        self._vlan_range = vlan_range
         self._status = status
         self._state = state
         self._nni = nni
@@ -196,25 +196,25 @@ class Port(Model):
         self._node = node
 
     @property
-    def label_range(self):
-        """Gets the label_range of this Port.
+    def vlan_range(self):
+        """Gets the vlan range of this Port.
 
 
-        :return: The label_range of this Port.
+        :return: The vlan_range of this Port.
         :rtype: List[str]
         """
-        return self._label_range
+        return self._vlan_range
 
-    @label_range.setter
-    def label_range(self, label_range):
-        """Sets the label_range of this Port.
+    @vlan_range.setter
+    def vlan_range(self, vlan_range):
+        """Sets the vlan range of this Port.
 
 
-        :param label_range: The label_range of this Port.
-        :type label_range: List[str]
+        :param vlan_range: The vlan range of this Port.
+        :type vlan_range: List[str]
         """
 
-        self._label_range = label_range
+        self._vlan_range = vlan_range
 
     @property
     def status(self):

--- a/src/sdx_datamodel/parsing/connectionhandler.py
+++ b/src/sdx_datamodel/parsing/connectionhandler.py
@@ -37,9 +37,7 @@ class ConnectionHandler:
                 ingress_port = self._make_port(endpoints[0], "")
                 egress_port = self._make_port(endpoints[1], "")
 
-                qos_metrics = data.get("qos_metrics")
-                if qos_metrics is None:
-                    raise MissingAttributeException(data, "qos_metrics")
+                qos_metrics = data.get("qos_metrics", {})
                 bandwidth_required_obj = qos_metrics.get("min_bw")
                 if bandwidth_required_obj is not None:
                     bandwidth_required = bandwidth_required_obj.get("value")
@@ -47,10 +45,7 @@ class ConnectionHandler:
                 if latency_required_obj is not None:
                     latency_required = latency_required_obj.get("value")
 
-                scheduling = data.get("scheduling")
-                if scheduling is None:
-                    raise MissingAttributeException(data, "scheduling")
-
+                scheduling = data.get("scheduling", {})
                 start_time = scheduling.get("start_time")
                 end_time = scheduling.get("end_time")
 
@@ -110,8 +105,9 @@ class ConnectionHandler:
             port_data["name"] = port_data["port_id"]
             del port_data["port_id"]
 
-        if port_data.get("vlan") is not None:
-            port_data["label_range"] = port_data["vlan"]
+        vlan = port_data.get("vlan")
+        if vlan is not None:
+            port_data["vlan_range"] = int(vlan) if vlan.isdigit() else vlan
             del port_data["vlan"]
 
         port_handler = PortHandler()

--- a/src/sdx_datamodel/parsing/porthandler.py
+++ b/src/sdx_datamodel/parsing/porthandler.py
@@ -25,11 +25,11 @@ class PortHandler:
             id = data["id"]
             name = data["name"]
 
-            # node, short_name, label_range, and private_attributes
+            # node, short_name, vlan_range, and private_attributes
             # are allowed to be None.
             node = data.get("node")
             short_name = data.get("short_name")
-            label_range = data.get("label_range")
+            vlan_range = data.get("vlan_range")
             status = data.get("status")
             state = data.get("state")
             private_attributes = data.get("private_attributes")
@@ -53,7 +53,7 @@ class PortHandler:
             name=name,
             short_name=short_name,
             node=node,
-            label_range=label_range,
+            vlan_range=vlan_range,
             status=status,
             state=state,
             nni=nni,

--- a/tests/data/port.json
+++ b/tests/data/port.json
@@ -1,8 +1,8 @@
 {
     "id": "id",
-    "label_range": [
-        "label_range",
-        "label_range"
+    "vlan_range": [
+        "vlan_range",
+        "vlan_range"
     ],
     "name": "urn:sdx:port:amlight.net:Novi06:9",
     "node": "urn:sdx:port:amlight.net:Novi06",

--- a/tests/test_connection_handler.py
+++ b/tests/test_connection_handler.py
@@ -203,6 +203,16 @@ class ConnectionHandlerTests(unittest.TestCase):
         )
         self.assertIsInstance(connection, Connection)
 
+        data = {
+            "name": "new-connection",
+            "endpoints": [
+                {"port_id": "id1", "vlan": "777"},
+                {"port_id": "id2"},
+            ],
+        }
+        with self.assertRaises(MissingAttributeException):
+            connection = ConnectionHandler().import_connection_data(data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_port_handler.py
+++ b/tests/test_port_handler.py
@@ -41,15 +41,13 @@ class PortHandlerTests(unittest.TestCase):
             "name": "a",
             "services": {"l2vpn-ptp": {"vlan_range": vlan_range}},
         }
-        self.assertIsInstance(
-            PortHandler().import_port_data(data), Port
-        )
+        self.assertIsInstance(PortHandler().import_port_data(data), Port)
 
-        vlan_range[0] = [1,2,3]
+        vlan_range[0] = [1, 2, 3]
         with self.assertRaises(InvalidVlanRangeException) as ex:
             PortHandler().import_port_data(data)
 
-        vlan_range[0] = [1,'2']
+        vlan_range[0] = [1, "2"]
         with self.assertRaises(InvalidVlanRangeException) as ex:
             PortHandler().import_port_data(data)
 

--- a/tests/test_port_handler.py
+++ b/tests/test_port_handler.py
@@ -2,7 +2,10 @@ import json
 import unittest
 
 from sdx_datamodel.models.port import Port
-from sdx_datamodel.parsing.exceptions import InvalidVlanRangeException
+from sdx_datamodel.parsing.exceptions import (
+    InvalidVlanRangeException,
+    MissingAttributeException,
+)
 from sdx_datamodel.parsing.porthandler import PortHandler
 
 from . import TestData
@@ -21,6 +24,39 @@ class PortHandlerTests(unittest.TestCase):
         self.assertIsInstance(
             PortHandler().import_port(TestData.PORT_FILE), Port
         )
+
+    def test_import_port_data(self):
+        """Test import_port_data function."""
+        self.assertIsInstance(
+            PortHandler().import_port_data({"id": "1", "name": "a"}), Port
+        )
+        with self.assertRaises(MissingAttributeException) as ex:
+            PortHandler().import_port_data({})
+
+    def test_validate_services_vlan_range(self):
+        """Test import_port_data function."""
+        vlan_range = [1, [10, 100], [300, 400]]
+        data = {
+            "id": "1",
+            "name": "a",
+            "services": {"l2vpn-ptp": {"vlan_range": vlan_range}},
+        }
+        self.assertIsInstance(
+            PortHandler().import_port_data(data), Port
+        )
+
+        vlan_range[0] = [1,2,3]
+        with self.assertRaises(InvalidVlanRangeException) as ex:
+            PortHandler().import_port_data(data)
+
+        vlan_range[0] = [1,'2']
+        with self.assertRaises(InvalidVlanRangeException) as ex:
+            PortHandler().import_port_data(data)
+
+        data["services"].pop("l2vpn-ptp")
+        data["services"]["l2vpn-ptmp"] = {"vlan_range": None}
+        with self.assertRaises(InvalidVlanRangeException) as ex:
+            PortHandler().import_port_data(data)
 
     def test_port_setters(self):
         port = PortHandler().import_port(TestData.PORT_FILE)


### PR DESCRIPTION
Related to #133 
Related to #130 
Related to atlanticwave-sdx/sdx-controller#302

Heads-up: This PR should sit on top of #135 

## Description of the changes

- rename label_range with vlan_range on Models/Port and Models/Connection
- Enhance ConnectionHandler to handle `qos_metrics` and `scheduling` as optional
- Enhance ConnectionHandler to convert VLAN into integer whenever possible (new implementation is needed to also handle "untagged", "all", "any" and range ("vlan1:vlanN")
- Adding new unit tests

## Local tests

Local tests shows that we can create a simplified L2VPN (i.e., minimal/required set of attributes):

- Submit a L2VPN connection creation:
```
curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/1.0.0/connection -d '{"name": "VLAN between AMPATH/334 and TENET/443", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "334"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "443"}]}'
```

- Logs on SDX-Controller:
```
sdx-controller  | INFO:sdx_controller.controllers.connection_controller:Placing connection: {'name': 'VLAN between AMPATH/334 and TENET/443', 'endpoints': [{'port_id': 'urn:sdx:port:ampath.net:Ampath3:50', 'vlan': '334'}, {'port_id': 'urn:sdx:port:tenet.ac.za:Tenet03:50', 'vlan': '443'}]}
sdx-controller  | INFO:sdx_controller.controllers.connection_controller:Gathered connexion JSON: {'name': 'VLAN between AMPATH/334 and TENET/443', 'endpoints': [{'port_id': 'urn:sdx:port:ampath.net:Ampath3:50', 'vlan': '334'}, {'port_id': 'urn:sdx:port:tenet.ac.za:Tenet03:50', 'vlan': '443'}]}
sdx-controller  | INFO:sdx_controller.controllers.connection_controller:Placing connection. Saving to database.
sdx-controller  | INFO:sdx_controller.controllers.connection_controller:Request has no ID. Generated ID: 1f68df41-00a4-40f6-b53a-f0579589e692
...
sdx-controller  | INFO:sdx_pce.topology.temanager:generate_connection_breakdown(): tagged_breakdown: VlanTaggedBreakdowns(breakdowns={'urn:sdx:topology:ampath.net': VlanTaggedBreakdown(name='AMPATH_vlan_334_4094', dynamic_backup_path=True, uni_a=VlanTaggedPort(tag=VlanTag(value=334, tag_type=1), port_id='urn:sdx:port:ampath.net:Ampath3:50'), uni_z=VlanTaggedPort(tag=VlanTag(value=4094, tag_type=1), port_id='urn:sdx:port:ampath.net:Ampath1:40')), 'urn:sdx:topology:sax.net': VlanTaggedBreakdown(name='SAX_vlan_4094_4094', dynamic_backup_path=True, uni_a=VlanTaggedPort(tag=VlanTag(value=4094, tag_type=1), port_id='urn:sdx:port:sax.net:Sax01:40'), uni_z=VlanTaggedPort(tag=VlanTag(value=4094, tag_type=1), port_id='urn:sdx:port:sax.net:Sax01:41')), 'urn:sdx:topology:tenet.ac.za': VlanTaggedBreakdown(name='TENET_vlan_4094_443', dynamic_backup_path=True, uni_a=VlanTaggedPort(tag=VlanTag(value=4094, tag_type=1), port_id='urn:sdx:port:tenet.ac.za:Tenet01:41'), uni_z=VlanTaggedPort(tag=VlanTag(value=443, tag_type=1), port_id='urn:sdx:port:tenet.ac.za:Tenet03:50'))})
sdx-controller  | INFO:sdx_controller.messaging.topic_queue_producer:Publishing link: {"operation": "post", "link": {"name": "AMPATH_vlan_334_4094", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 334, "tag_type": 1}, "port_id": "urn:sdx:port:ampath.net:Ampath3:50"}, "uni_z": {"tag": {"value": 4094, "tag_type": 1}, "port_id": "urn:sdx:port:ampath.net:Ampath1:40"}}}, MQ_HOST: 192.168.0.12, MQ_PORT: 5672, exchange_name: connection, routing_key: ampath.net
sdx-controller  | INFO:sdx_controller.messaging.topic_queue_producer:Publishing link: {"operation": "post", "link": {"name": "SAX_vlan_4094_4094", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 4094, "tag_type": 1}, "port_id": "urn:sdx:port:sax.net:Sax01:40"}, "uni_z": {"tag": {"value": 4094, "tag_type": 1}, "port_id": "urn:sdx:port:sax.net:Sax01:41"}}}, MQ_HOST: 192.168.0.12, MQ_PORT: 5672, exchange_name: connection, routing_key: sax.net
sdx-controller  | INFO:sdx_controller.messaging.topic_queue_producer:Publishing link: {"operation": "post", "link": {"name": "TENET_vlan_4094_443", "dynamic_backup_path": true, "uni_a": {"tag": {"value": 4094, "tag_type": 1}, "port_id": "urn:sdx:port:tenet.ac.za:Tenet01:41"}, "uni_z": {"tag": {"value": 443, "tag_type": 1}, "port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50"}}}, MQ_HOST: 192.168.0.12, MQ_PORT: 5672, exchange_name: connection, routing_key: tenet.ac.za
sdx-controller  | INFO:sdx_controller.controllers.connection_controller:place_connection result: ID: 1f68df41-00a4-40f6-b53a-f0579589e692 reason='Connection published', code=200
```