### PR TITLE
Adding status and state attributes to LinkHandler when importing data

### DIFF
--- a/src/sdx_datamodel/parsing/linkhandler.py
+++ b/src/sdx_datamodel/parsing/linkhandler.py
@@ -25,6 +25,8 @@ class LinkHandler:
             packet_loss = data.get("packet_loss")
             private_attributes = data.get("private_attributes")
             availability = data.get("availability")
+            status = data.get("status")
+            state = data.get("state")
             measurement_period = data.get("measurement_period")
         except KeyError as e:
             raise MissingAttributeException(data, e.args[0])
@@ -39,6 +41,8 @@ class LinkHandler:
             latency=latency,
             packet_loss=packet_loss,
             availability=availability,
+            status=status,
+            state=state,
             private_attributes=private_attributes,
             timestamp=timestamp,
             measurement_period=measurement_period,


### PR DESCRIPTION
Fix #137 

### Description of the change

Topology Data Model spec 2.0.0 states that the link contains some attributes like state and status (as well as others). In particular, state and status were already defined on the Link object by PR #121. However, the LinkHandler component was left behind and it was not importing those attributes as expected.

This PR basically adds state and status into the process.