### PR TITLE
Adding Port.type attribute according to Topology 2.0 spec

### DIFF
--- a/src/sdx_datamodel/models/port.py
+++ b/src/sdx_datamodel/models/port.py
@@ -26,6 +26,7 @@ class Port(Model):
         status=None,
         state=None,
         nni=None,
+        type=None,
         services=None,
         private_attributes=None,
     ):  # noqa: E501
@@ -47,6 +48,8 @@ class Port(Model):
         :type state: str
         :param nni: The nni of this Port.  # noqa: E501
         :type nni: str
+        :param type: The technology/bandwidth of this Port.  # noqa: E501
+        :type type: str
         :param services: The services of this Port.  # noqa: E501
         :type services: Service
         :param private_attributes: The private_attributes of this Port.  # noqa: E501
@@ -61,6 +64,7 @@ class Port(Model):
             "status": str,
             "state": str,
             "nni": str,
+            "type": str,
             "services": Service,
             "private_attributes": List[str],
         }
@@ -74,6 +78,7 @@ class Port(Model):
             "status": "status",
             "state": "state",
             "nni": "nni",
+            "type": "type",
             "services": "services",
             "private_attributes": "private_attributes",
         }
@@ -85,6 +90,7 @@ class Port(Model):
         self._status = status
         self._state = state
         self._nni = nni
+        self._type = type
         self._services = services
         self._private_attributes = private_attributes
 
@@ -282,6 +288,26 @@ class Port(Model):
         """
 
         self._nni = nni
+
+    @property
+    def type(self):
+        """Gets the type of this Port.
+
+
+        :return: The type of this Port.
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, type):
+        """Sets the type of this Port.
+
+
+        :param type: The type of this Port.
+        :type type: str
+        """
+        self._type = type
 
     @property
     def services(self):

--- a/src/sdx_datamodel/parsing/porthandler.py
+++ b/src/sdx_datamodel/parsing/porthandler.py
@@ -34,6 +34,7 @@ class PortHandler:
             state = data.get("state")
             private_attributes = data.get("private_attributes")
             nni = data.get("nni")
+            type = data.get("type")
             # L2VPN services are optional.
             #
             # TODO: actually use the services value.  We might want to
@@ -57,6 +58,7 @@ class PortHandler:
             status=status,
             state=state,
             nni=nni,
+            type=type,
             services=services,
             private_attributes=private_attributes,
         )

--- a/tests/data/port_v2.json
+++ b/tests/data/port_v2.json
@@ -1,0 +1,19 @@
+{
+    "id": "urn:sdx:port:amlight.net:s3:s3-eth4",
+    "name": "s3-eth4",
+    "node": "urn:sdx:node:amlight.net:s3",
+    "type": "100GE",
+    "mtu": 9000,
+    "status": "up",
+    "state": "enabled",
+    "nni": "urn:sdx:link:amlight.net:Novi03/2_s3/s3-eth2",
+    "services": {
+        "l2vpn-ptp": {
+            "vlan_range": [[1,4000]]
+        },
+        "l2vpn-ptmp": {
+            "vlan_range": [[1,1000], [2000,3000]]
+        }
+    },
+    "private": ["state", "mtu"]
+}

--- a/tests/test_port_handler.py
+++ b/tests/test_port_handler.py
@@ -22,6 +22,15 @@ class PortHandlerTests(unittest.TestCase):
             PortHandler().import_port(TestData.PORT_FILE), Port
         )
 
+    def test_import_port_v2_json(self):
+        """
+        Test that a Port object can be created given a JSON
+        descritpion of a port using Topology v2 format.
+        """
+        self.assertIsInstance(
+            PortHandler().import_port(TestData.PORT_FILE_V2), Port
+        )
+
     def test_port_setters(self):
         port = PortHandler().import_port(TestData.PORT_FILE)
         self.assertIsInstance(port, Port)


### PR DESCRIPTION
Fix #139 

Heads-up: this PR will sits on top of PR #138 

### Description of the change

- Adding `Port.type` attribute on the Port object and PortHandler
- Adding unit tests
- Adding `port_v2.json` testing data model file