### PR TITLE
Use flit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip flit
-          pip install .[test,lint]
+          python -m pip install --upgrade pip
+          pip install .[test,lint] flit
 
       - name: Lint with ruff
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - name: Check out code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip flit
           pip install .[test,lint]
 
       - name: Lint with ruff
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build packages
         run: |
-          python -m build
+          python -m flit build
 
       - name: Send coverage data to coveralls.io
         uses: coverallsapp/github-action@v2

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Italo Valcy <italo@ampath.net> <italovalcy@gmail.com>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ version = "3.0.0.dev0"
 description = "Topology and request description data model in JSON"
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },
-    { name = "Sajith Sasidharan", email = "sajith@renci.org" }
+    { name = "Sajith Sasidharan", email = "sajith@renci.org" },
+    { name = "Cong Wang", email = "cwang@renci.org" },
+    { name = "Italo Valcy", email = "italo@ampath.net" },
 ]
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Italo Valcy", email = "italo@ampath.net" },
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,11 @@
 [build-system]
-requires = [
-    "setuptools >= 61.0",
-    "setuptools-scm >= 6.2"
-]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdx-datamodel"
+version = "3.0.0.dev0"
 description = "Topology and request description data model in JSON"
-dynamic = [ "version" ]
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },
     { name = "Sajith Sasidharan", email = "sajith@renci.org" }

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 env_list =
-    py38
     py39
     py310
     py311
+    py312
 
 skip_missing_interpreters = true
 


### PR DESCRIPTION
[Why use Flit?](https://flit.pypa.io/en/latest/rationale.html) explains reasons for using flit.  Flit is faster and stricter, so it should catch packaging mistakes.

On the downside, we will lose the ability to get scm info when doing a `pip list` etc (currently we get something like `2.0.6rc5.dev13+g312996a` for dev builds which provides more information that can be occasionally useful).  On the upside, setuptools + setuptools_scm is slower, and setuptools_scm broke our workflow (where we used `devX` tags) without notice.

Also bump version up to `3.0.0.dev0`.