### PR TITLE
Add constants

### DIFF
--- a/src/sdx_datamodel/constants.py
+++ b/src/sdx_datamodel/constants.py
@@ -14,3 +14,9 @@ class Constants:
     LATEST_TOPOLGY = "latest_topology"
     LATEST_TOPOLOGY_TS = "latest_topology_ts"
     TOPOLOGY_VERSION = "topology_version"
+
+
+class MessageQueueNames:
+    OXP_UPDATE = "oxp_update"
+    CONNECTIONS = "connections"
+    SDX_QUEUE_1 = "sdx_queue_1"

--- a/src/sdx_datamodel/constants.py
+++ b/src/sdx_datamodel/constants.py
@@ -1,0 +1,16 @@
+class MongoCollections:
+    TOPOLOGIES = "topologies"
+    CONNECTIONS = "connections"
+    BREAKDOWNS = "breakdowns"
+    DOMAINS = "domains"
+    LINKS = "links"
+    HISTORICAL_CONNECTIONS = "historical_connections"
+
+
+class Constants:
+    DOMAIN_LIST = "domain_list"
+    LATEST_TOPO = "latest_topo"
+    LINK_CONNECTIONS_DICT = "link_connections_dict"
+    LATEST_TOPOLGY = "latest_topology"
+    LATEST_TOPOLOGY_TS = "latest_topology_ts"
+    TOPOLOGY_VERSION = "topology_version"


### PR DESCRIPTION
Move the constants from sdx-controller/lc to datamodel, so both of them can use the shared constants.
Also add MQ related constants.
Currently not adding BAPM related constants, because BAPM might be deployed and maintained by OXP, they may want it to be configurable via env var. We can always add this later.