### PR TITLE
Remove duplicate const

### DIFF
--- a/src/sdx_datamodel/constants.py
+++ b/src/sdx_datamodel/constants.py
@@ -9,9 +9,8 @@ class MongoCollections:
 
 class Constants:
     DOMAIN_LIST = "domain_list"
-    LATEST_TOPO = "latest_topo"
     LINK_CONNECTIONS_DICT = "link_connections_dict"
-    LATEST_TOPOLGY = "latest_topology"
+    LATEST_TOPOLOGY = "latest_topology"
     LATEST_TOPOLOGY_TS = "latest_topology_ts"
     TOPOLOGY_VERSION = "topology_version"
 


### PR DESCRIPTION
We'll just use LATEST_TOPOLOGY for better naming and consistency. And also fix a typo.