### PR TITLE
Fix valid transition list with correct destination from RECOVERING

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdx-datamodel"
-version = "3.0.0.dev6"
+version = "3.0.0.dev7"
 description = "Topology and request description data model in JSON"
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },

--- a/src/sdx_datamodel/connection_sm.py
+++ b/src/sdx_datamodel/connection_sm.py
@@ -183,7 +183,7 @@ class ConnectionStateMachine:
             self.State.ERROR: [self.State.RECOVERING],
             self.State.RECOVERING: [
                 self.State.UP,
-                self.State.DOWN,
+                self.State.ERROR,
             ],
             self.State.DELETED: [],
         }


### PR DESCRIPTION
Fix #180 

### Description of the change

This PR fixes the valid_transition list with the correct destination state when coming from RECOVERING.