### PR TITLE
Load vlan_range saved to MongoDB

### DIFF
--- a/src/sdx_datamodel/parsing/porthandler.py
+++ b/src/sdx_datamodel/parsing/porthandler.py
@@ -94,8 +94,9 @@ class PortHandler:
         l2vpn_ptp = {}
         l2vpn_ptmp = {}
         for service_type in ["l2vpn-ptp", "l2vpn_ptp"]:
-            vlan_range = services.get(service_type, {}).get("vlan_range")
-            if not vlan_range: continue
+            if not isinstance(services.get(service_type), dict):
+                continue
+            vlan_range = services[service_type].get("vlan_range")
             l2vpn_ptp_vlan_range = self._validate_vlan_range(vlan_range)
             l2vpn_ptp["vlan_range"] = l2vpn_ptp_vlan_range
             break
@@ -103,8 +104,9 @@ class PortHandler:
             l2vpn_ptp_vlan_range = None
 
         for service_type in ["l2vpn-ptmp", "l2vpn_ptmp"]:
-            vlan_range = services.get(service_type, {}).get("vlan_range")
-            if not vlan_range: continue
+            if not isinstance(services.get(service_type), dict):
+                continue
+            vlan_range = services[service_type].get("vlan_range")
             l2vpn_ptmp_vlan_range = self._validate_vlan_range(vlan_range)
             l2vpn_ptmp["vlan_range"] = l2vpn_ptmp_vlan_range
             break


### PR DESCRIPTION
Fix #188 

Heads-UP: this PR sits on top of PR #187 

### Description of the change

This PR enhances the VLAN validation routine to also allow loading the VLAN range in the same format that datamodel is saving: list of strings where each string can be a "start-end" or "vlanid"