### PR TITLE
Accept VLAN range [3000, 3000] as valid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdx-datamodel"
-version = "3.0.0.dev12"
+version = "3.0.0.dev13"
 description = "Topology and request description data model in JSON"
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },

--- a/src/sdx_datamodel/parsing/porthandler.py
+++ b/src/sdx_datamodel/parsing/porthandler.py
@@ -166,13 +166,13 @@ class PortHandler:
                         f"VLAN ranges in {item} must be numbers, but it is not"
                     )
 
-                if item[0] >= item[1]:
+                if item[0] > item[1]:
                     raise InvalidVlanRangeException(
-                        f"VLAN range {item} is invalid: {item[0]} >= {item[1]}"
+                        f"VLAN range {item} is invalid: {item[0]} > {item[1]}"
                     )
                 if item[0] < 0 or item[1] < 0:
                     raise InvalidVlanRangeException(
-                        f"VLAN range {item} is invalid: {item[0]} or {item[1]} < 0"
+                        f"VLAN range {item} is invalid: {item[0]} or {item[1]} < 1"
                     )
                 if item[0] > 4095 or item[1] > 4095:
                     raise InvalidVlanRangeException(

--- a/src/sdx_datamodel/validation/connectionvalidator.py
+++ b/src/sdx_datamodel/validation/connectionvalidator.py
@@ -1,4 +1,4 @@
-"""""
+""" ""
 Checks for Connection objects to be in the expected format.
 """
 

--- a/src/sdx_datamodel/validation/connectionvalidator.py
+++ b/src/sdx_datamodel/validation/connectionvalidator.py
@@ -1,4 +1,4 @@
-""" ""
+"""
 Checks for Connection objects to be in the expected format.
 """
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -167,42 +167,45 @@ class JSONSchemaTests(unittest.TestCase):
     def test_vlan_range_valid(self):
         # Valid VLAN ranges
         valid_ranges = [
-            [1, 1],       # item0 == item1
-            [1, 4095],    # item0 > 0, item1 <= 4095
-            [100, 200],   # typical valid range
-            [4000, 4000]  # item0 == item1, within bounds
+            [1, 1],  # item0 == item1
+            [1, 4095],  # item0 > 0, item1 <= 4095
+            [100, 200],  # typical valid range
+            [4000, 4000],  # item0 == item1, within bounds
         ]
         for r in valid_ranges:
             vlan_data = {
-                            "id":'urn:sdx:port:amlight.net:s3:s3-eth2', 
-                            'name': 's3-eth2',
-                            'node': 'urn:sdx:node:amlight.net:s3',
-                            "status": "up", 
-                            "services": {"l2vpn-ptp": {"vlan_range": [r]}}
-                        }
-            jsonschema.validate(vlan_data, self._read_schema(self.PORT_SCHEMA_FILE))
+                "id": "urn:sdx:port:amlight.net:s3:s3-eth2",
+                "name": "s3-eth2",
+                "node": "urn:sdx:node:amlight.net:s3",
+                "status": "up",
+                "services": {"l2vpn-ptp": {"vlan_range": [r]}},
+            }
+            jsonschema.validate(
+                vlan_data, self._read_schema(self.PORT_SCHEMA_FILE)
+            )
 
     def test_vlan_range_invalid(self):
         # Invalid VLAN ranges
         invalid_ranges = [
-            [200, 100],   # item0 > item1
-            [0, 100],     # item0 <= 0
-            [1, 0],       # item1 <= 0
-            [4096, 4096], # item0 > 4095
-            [1, 4096],    # item1 > 4095
-            [-1, 100],    # item0 negative
-            [100, -1]     # item1 negative
+            [200, 100],  # item0 > item1
+            [0, 100],  # item0 <= 0
+            [1, 0],  # item1 <= 0
+            [4096, 4096],  # item0 > 4095
+            [1, 4096],  # item1 > 4095
+            [-1, 100],  # item0 negative
+            [100, -1],  # item1 negative
         ]
         for r in invalid_ranges:
             vlan_data = {
-                            "id":'urn:sdx:port:amlight.net:s3:s3-eth2', 
-                            'name': 's3-eth2',
-                            'node': 'urn:sdx:node:amlight.net:s3',
-                            "status": "up", 
-                            "services": {"l2vpn-ptp": {"vlan_range": [r]}}
-                        }
-            jsonschema.validate(vlan_data, self._read_schema(self.PORT_SCHEMA_FILE))
-
+                "id": "urn:sdx:port:amlight.net:s3:s3-eth2",
+                "name": "s3-eth2",
+                "node": "urn:sdx:node:amlight.net:s3",
+                "status": "up",
+                "services": {"l2vpn-ptp": {"vlan_range": [r]}},
+            }
+            jsonschema.validate(
+                vlan_data, self._read_schema(self.PORT_SCHEMA_FILE)
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -164,6 +164,46 @@ class JSONSchemaTests(unittest.TestCase):
             self._read_schema(self.TOPOLOGY_SCHEMA_FILE),
         )
 
+    def test_vlan_range_valid(self):
+        # Valid VLAN ranges
+        valid_ranges = [
+            [1, 1],       # item0 == item1
+            [1, 4095],    # item0 > 0, item1 <= 4095
+            [100, 200],   # typical valid range
+            [4000, 4000]  # item0 == item1, within bounds
+        ]
+        for r in valid_ranges:
+            vlan_data = {
+                            "id":'urn:sdx:port:amlight.net:s3:s3-eth2', 
+                            'name': 's3-eth2',
+                            'node': 'urn:sdx:node:amlight.net:s3',
+                            "status": "up", 
+                            "services": {"l2vpn-ptp": {"vlan_range": [r]}}
+                        }
+            jsonschema.validate(vlan_data, self._read_schema(self.PORT_SCHEMA_FILE))
+
+    def test_vlan_range_invalid(self):
+        # Invalid VLAN ranges
+        invalid_ranges = [
+            [200, 100],   # item0 > item1
+            [0, 100],     # item0 <= 0
+            [1, 0],       # item1 <= 0
+            [4096, 4096], # item0 > 4095
+            [1, 4096],    # item1 > 4095
+            [-1, 100],    # item0 negative
+            [100, -1]     # item1 negative
+        ]
+        for r in invalid_ranges:
+            vlan_data = {
+                            "id":'urn:sdx:port:amlight.net:s3:s3-eth2', 
+                            'name': 's3-eth2',
+                            'node': 'urn:sdx:node:amlight.net:s3',
+                            "status": "up", 
+                            "services": {"l2vpn-ptp": {"vlan_range": [r]}}
+                        }
+            jsonschema.validate(vlan_data, self._read_schema(self.PORT_SCHEMA_FILE))
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This fix issue [#497 in sdx-controller](https://github.com/atlanticwave-sdx/sdx-controller/issues/497).

Currently, a range (item0, item1) is considered invalid when item0 == item1. This PR updates the logic to treat such a range as valid.


## Tests:

Two new unit tests have been added and verified to pass.

```
================================================================================== tests coverage ==================================================================================
_________________________________________________________________ coverage: platform linux, python 3.11.2-final-0 __________________________________________________________________

Name                                                  Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------------------
src/sdx_datamodel/__init__.py                             0      0      0      0   100%
src/sdx_datamodel/connection_sm.py                       90     90      2      0     0%   1-316
src/sdx_datamodel/constants.py                           19     19      0      0     0%   1-23
src/sdx_datamodel/models/__init__.py                      9      0      0      0   100%
src/sdx_datamodel/models/base_model_.py                  27      2      8      0    94%   20, 73
src/sdx_datamodel/models/connection.py                  200     29      0      0    86%   183, 253-258, 279-280, 300-305, 326-327, 348, 411, 432, 452-460, 481, 502, 544, 586, 607, 628, 649, 670, 691, 712, 734-747, 768
src/sdx_datamodel/models/connection_qos_metrics.py       76     19      0      0    75%   96, 106, 117, 127, 138, 148, 159, 169, 180, 190, 201, 211, 222, 232, 243, 253, 264, 274, 285
src/sdx_datamodel/models/connection_qos_unit.py          26      9      0      0    65%   26-30, 41, 51, 62, 72, 83
src/sdx_datamodel/models/connection_scheduling.py        26      5      0      0    81%   44, 54, 65, 75, 86
src/sdx_datamodel/models/connection_v2.py               139     36      0      0    74%   141, 161-166, 186-191, 211-216, 236-241, 251, 261-266, 286-291, 311-316, 337, 348, 359-372, 382, 393, 403, 414, 424, 435, 445, 456, 466, 476-484, 505, 515, 526
src/sdx_datamodel/models/link.py                        123     16      4      1    87%   128, 153, 178, 199, 219-224, 236->239, 263, 284, 305, 326, 347, 368, 389, 410, 431, 452
src/sdx_datamodel/models/link_measurement_period.py      26      3      0      0    88%   41, 62, 83
src/sdx_datamodel/models/location.py                     40      1      0      0    98%   59
src/sdx_datamodel/models/node.py                         97     15      6      2    83%   85, 96, 121, 146, 166-171, 191-196, 217, 237-242, 278-283, 296, 324
src/sdx_datamodel/models/port.py                        101     12      0      0    88%   112, 183, 204, 224-229, 270-275, 296, 317, 337, 358, 379
src/sdx_datamodel/models/service.py                      68      9      0      0    87%   87, 108, 129, 150, 171, 192, 213, 234, 255
src/sdx_datamodel/models/topology.py                    186     33     52      4    78%   109, 134, 159, 180, 217-222, 243, 263-268, 339-340, 345->343, 349, 352->exit, 366->352, 388-390, 399-402, 422-427, 446-448, 455, 458-461, 482, 485, 488, 491
src/sdx_datamodel/parsing/__init__.py                     0      0      0      0   100%
src/sdx_datamodel/parsing/connectionhandler.py           59      0     14      3    96%   51->53, 54->56, 56->61
src/sdx_datamodel/parsing/exceptions.py                  29      7      0      0    76%   16, 19, 32, 67, 80-81, 84
src/sdx_datamodel/parsing/linkhandler.py                 26      0      0      0   100%
src/sdx_datamodel/parsing/locationhandler.py             13      0      0      0   100%
src/sdx_datamodel/parsing/nodehandler.py                 20      0      0      0   100%
src/sdx_datamodel/parsing/porthandler.py                 73      3     20      1    94%   148-150
src/sdx_datamodel/parsing/servicehandler.py              31      2      6      1    86%   30-31
src/sdx_datamodel/parsing/topologyhandler.py             20      1      0      0    95%   24
src/sdx_datamodel/topology_sm.py                         34      0      0      0   100%
src/sdx_datamodel/type_util.py                           15     10      2      1    35%   6-18, 24, 28, 32
src/sdx_datamodel/util.py                                56     44     22      0    15%   17-34, 46-52, 60, 71-76, 89-94, 105-119, 132, 145
src/sdx_datamodel/validation/__init__.py                  0      0      0      0   100%
src/sdx_datamodel/validation/connectionvalidator.py     126     21     62     12    80%   114, 138, 166-169, 172-175, 178-182, 185-189, 193, 202, 214, 224, 265-269, 305, 311
src/sdx_datamodel/validation/topologyvalidator.py        99     25     52      7    74%   75, 101-104, 123-137, 183, 189, 224, 226, 230, 234, 283-284, 301-302, 310-311
-------------------------------------------------------------------------------------------------
TOTAL                                                  1854    411    250     32    76%
Coverage HTML written to dir htmlcov
========================================================================== 121 passed, 1 skipped in 1.80s ==========================================================================
```