### PR TITLE
Add domain status consts

### DIFF
--- a/src/sdx_datamodel/constants.py
+++ b/src/sdx_datamodel/constants.py
@@ -10,6 +10,7 @@ class MongoCollections:
 
 class Constants:
     DOMAIN_LIST = "domain_list"
+    DOMAIN_DICT = "domain_dict"
     LINK_CONNECTIONS_DICT = "link_connections_dict"
     PORT_CONNECTIONS_DICT = "port_connections_dict"
     LATEST_TOPOLOGY = "latest_topology"
@@ -21,3 +22,10 @@ class MessageQueueNames:
     OXP_UPDATE = "oxp_update"
     CONNECTIONS = "connections"
     SDX_QUEUE_1 = "sdx_queue_1"
+
+
+class DomainStatus:
+    UP = "UP"
+    DOWN = "DOWN"
+    ERROR = "ERROR"
+    UNKNOWN = "UNKNOWN"

--- a/src/sdx_datamodel/constants.py
+++ b/src/sdx_datamodel/constants.py
@@ -9,7 +9,6 @@ class MongoCollections:
 
 
 class Constants:
-    DOMAIN_LIST = "domain_list"
     DOMAIN_DICT = "domain_dict"
     LINK_CONNECTIONS_DICT = "link_connections_dict"
     PORT_CONNECTIONS_DICT = "port_connections_dict"


### PR DESCRIPTION
Add domain status consts. Per discussion earlier (https://github.com/atlanticwave-sdx/sdx-controller/issues/492), we will update domain status to unknown if missing a pre-configured number of heartbeats.